### PR TITLE
Padronização dos Controllers

### DIFF
--- a/infra/controller.ts
+++ b/infra/controller.ts
@@ -1,0 +1,35 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { InternalServerError, MethodNotAllowedError } from "./errors";
+import { isErrorWithStatusCode } from "./utils";
+
+function onNoMatchHandler(_request: NextApiRequest, response: NextApiResponse) {
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+function onErrorHandler(
+  error: unknown,
+  _request: NextApiRequest,
+  response: NextApiResponse,
+) {
+  const statusCode = isErrorWithStatusCode(error)
+    ? error.statusCode
+    : undefined;
+
+  const publicErrorObject = new InternalServerError({
+    cause: error,
+    statusCode: statusCode,
+  });
+
+  console.error(publicErrorObject);
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+};
+
+export default controller;

--- a/infra/database.ts
+++ b/infra/database.ts
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { ServiceError } from "./errors";
 
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 async function query(queryObject: any) {
@@ -8,8 +9,11 @@ async function query(queryObject: any) {
     const result = await client.query(queryObject);
     return result;
   } catch (error) {
-    console.error(error);
-    throw error;
+    const serviceErrorObject = new ServiceError({
+      message: "Erro na conexão com Banco ou na Query.",
+      cause: error,
+    });
+    throw serviceErrorObject;
   } finally {
     await client?.end();
   }

--- a/infra/errors.ts
+++ b/infra/errors.ts
@@ -1,16 +1,18 @@
 type InternalServerErrorOptions = {
+  statusCode?: number;
   cause: unknown;
 };
 
 export class InternalServerError extends Error {
   public readonly action = "Entre em contato com o suporte.";
-  public readonly status_code = 500;
+  public statusCode: number;
 
-  constructor({ cause }: InternalServerErrorOptions) {
+  constructor({ cause, statusCode }: InternalServerErrorOptions) {
     super("Um erro interno não esperado aconteceu.", {
       cause,
     });
 
+    this.statusCode = statusCode ?? 500;
     this.name = "InternalServerError";
   }
 
@@ -19,7 +21,54 @@ export class InternalServerError extends Error {
       name: this.name,
       message: this.message,
       action: this.action,
-      status_code: this.status_code,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+type ServiceErrorOptions = {
+  message?: string;
+  cause: unknown;
+};
+
+export class ServiceError extends Error {
+  public readonly action = "Verifique se o serviço está disponível.";
+  public readonly statusCode = 503;
+
+  constructor({ cause, message }: ServiceErrorOptions) {
+    super(message ?? "Serviço indisponível no momento.", {
+      cause,
+    });
+
+    this.name = "ServiceError";
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class MethodNotAllowedError extends Error {
+  public readonly action =
+    "Verifique se o método HTTP enviado é válido para este endpoint.";
+  public readonly statusCode = 405;
+
+  constructor() {
+    super("Método não permitido para este endpoint.");
+    this.name = "MethodNotAllowedError";
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
     };
   }
 }

--- a/infra/utils.ts
+++ b/infra/utils.ts
@@ -1,0 +1,10 @@
+export function isErrorWithStatusCode(
+  error: unknown,
+): error is { statusCode: number } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "statusCode" in error &&
+    typeof error["statusCode"] === "number"
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "14.2.6",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
@@ -8859,6 +8860,18 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9890,6 +9903,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "14.2.6",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/status/index.ts
+++ b/pages/api/v1/status/index.ts
@@ -1,47 +1,45 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import database from "@/infra/database";
 import { APIStatusResponse } from "@/types/pages/api/v1/status";
-import { InternalServerError } from "@/infra/errors";
 
-export default async function status(
-  _request: NextApiRequest,
-  response: NextApiResponse,
-) {
-  try {
-    const updatedAt = new Date().toISOString();
+import { createRouter } from "next-connect";
+import controller from "@/infra/controller";
 
-    const databaseVersionResult = await database.query("SHOW server_version;");
-    const databaseVersionValue = databaseVersionResult.rows[0].server_version;
+const router = createRouter<NextApiRequest, NextApiResponse>();
 
-    const databaseMaxConnectionsResult = await database.query(
-      "SHOW max_connections;",
-    );
-    const databaseMaxConnectionsValue =
-      databaseMaxConnectionsResult.rows[0].max_connections;
+router.get(getHandler);
 
-    const databaseName = process.env.POSTGRES_DB;
-    const databaseOpenedConnectionsResult = await database.query({
-      text: "SELECT count(*)::int as opened_connections FROM pg_stat_activity WHERE datname = $1;",
-      values: [databaseName],
-    });
-    const databaseOpenedConnectionsValue =
-      databaseOpenedConnectionsResult.rows[0].opened_connections;
+export default router.handler(controller.errorHandlers);
 
-    const responseBody: APIStatusResponse = {
-      updated_at: updatedAt,
-      dependencies: {
-        database: {
-          version: databaseVersionValue,
-          max_connections: parseInt(databaseMaxConnectionsValue),
-          opened_connections: databaseOpenedConnectionsValue,
-        },
+async function getHandler(_request: NextApiRequest, response: NextApiResponse) {
+  const updatedAt = new Date().toISOString();
+  const databaseVersionResult = await database.query("SHOW server_version;");
+  const databaseVersionValue = databaseVersionResult.rows[0].server_version;
+
+  const databaseMaxConnectionsResult = await database.query(
+    "SHOW max_connections;",
+  );
+  const databaseMaxConnectionsValue =
+    databaseMaxConnectionsResult.rows[0].max_connections;
+
+  const databaseName = process.env.POSTGRES_DB;
+  const databaseOpenedConnectionsResult = await database.query({
+    text: "SELECT count(*)::int as opened_connections FROM pg_stat_activity WHERE datname = $1;",
+    values: [databaseName],
+  });
+  const databaseOpenedConnectionsValue =
+    databaseOpenedConnectionsResult.rows[0].opened_connections;
+
+  const responseBody: APIStatusResponse = {
+    updated_at: updatedAt,
+    dependencies: {
+      database: {
+        version: databaseVersionValue,
+        max_connections: parseInt(databaseMaxConnectionsValue),
+        opened_connections: databaseOpenedConnectionsValue,
       },
-    };
+    },
+  };
 
-    response.status(200).json(responseBody);
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({ cause: error });
-    console.error(publicErrorObject);
-    response.status(500).json(publicErrorObject);
-  }
+  response.status(200).json(responseBody);
 }

--- a/tests/integration/api/v1/status/post.test.ts
+++ b/tests/integration/api/v1/status/post.test.ts
@@ -1,0 +1,26 @@
+import { APIStatusResponse } from "@/types/pages/api/v1/status";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+describe("POST /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Retrieving current system status", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint.",
+        action:
+          "Verifique se o método HTTP enviado é válido para este endpoint.",
+        status_code: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
1. Padroniza os Controllers dos endpoints `/migrations` e `/status`.
2. Adiciona 2 novos erros customizados: `MethodNotAllowedError` e `ServiceError`.
3. Faz o `InternalServerError` aceitar injeção do s`tatusCode`.